### PR TITLE
Update vermont meshlocals

### DIFF
--- a/meshlocals.md
+++ b/meshlocals.md
@@ -215,6 +215,11 @@ https://www.reddit.com/user/Famicoman/m/meshlocals/new
     * Dallas
 * Utah
 * Vermont
+  * https://newportmesh.org
+    * Newport Mesh
+  * https://btvmesh.org
+    * Burlington Community Mesh / Vermont Community Internet project
+	
 * Virginia
   * https://reddit.com/r/VirginiaMesh
     * Virginia general

--- a/meshlocals.md
+++ b/meshlocals.md
@@ -61,7 +61,7 @@ https://www.reddit.com/user/Famicoman/m/meshlocals/new
 
 * Alberta
   * https://reddit.com/r/YYCMeshNet
-    *Calgary
+    * Calgary
 * British Columbia
   * https://reddit.com/r/VancouverMeshnet
     * Vancouver
@@ -73,7 +73,8 @@ https://www.reddit.com/user/Famicoman/m/meshlocals/new
 * Toronto
   * https://reddit.com/r/tomesh
     * Toronto general, absorbs /r/meshto, /r/torontomesh, /r/torontomeshnet
-
+  * https://www.tomesh.net
+    * Tomesh's general website
 
 ### Mexico
 


### PR DESCRIPTION
I'm merging this to make some small updates.

At some point I think it'd be worth agreeing upon (as a collection of communities) a central point for organizing mesh stuff. As it stands, our directories are sprawled and span many disconnected and aging sites, and as I see it the only way to fix that is to stand up a simple central webpage / wiki that acts as a directory.

Since a lot of these sites (phillymesh, tomesh, etc.) seem to be statically generated it might make sense to reach out to many of these projects and have them static-generate a page from a single host that lists out stuff, and put it up `directory.$SITE.net`?